### PR TITLE
Fix an infinite loop bug that only occurs in IE versions prior to 9.

### DIFF
--- a/jquery.routes.js
+++ b/jquery.routes.js
@@ -269,7 +269,7 @@
 	}
 	
 	// create array data types
-	var dts = $.routes.datatypes;
+	var dts = $.extend({},$.routes.datatypes);
 	for (var name in dts) {
 		if (dts.hasOwnProperty(name)) {
 			createDatatypeArray(name);


### PR DESCRIPTION
`createDataTypeArray` modifies `$.routes.datatypes` during iteration, adding new attributes. In IE versions < 9 the change is visible during iteration. I tested the fix using IE9's browser modes (not on "real" IE7 and IE8) but that was how I discovered the problem to begin with.

Thank you for the great library.
