### PR TITLE
add route name to callback

### DIFF
--- a/jquery.routes.js
+++ b/jquery.routes.js
@@ -221,7 +221,7 @@
 						location.href = this.url(data);
 					},
 					execute: function(data) {
-						this.func.apply($.extend({}, defaults, data));
+			                        this.func.apply($.extend({}, {routeName: name}, defaults, data));
 					},
 					vars: vars,
 					defaults: defaults,


### PR DESCRIPTION
when sharing the callback , the route name is useful for recognize , check the example.

``` javascript

$.routes.add('/courses/', "courses", routeHandler);
$.routes.add('/course/{id:int}', "course", routeHandler);

function routeHandler () {
    switch (this.routeName) {
        case "courses":
            console.log("courses");
            // TODO render template courses
            break;
        case "course":
            console.log("course ->" , this.id);
            // TODO render template only one course
            break;
    }
};
```
